### PR TITLE
cmake: run target now wraps `west flash --runner=qemu`

### DIFF
--- a/cmake/emu/qemu.cmake
+++ b/cmake/emu/qemu.cmake
@@ -43,7 +43,8 @@ if(CONFIG_QEMU_UEFI_BOOT)
 endif()
 
 set(qemu_targets
-  run_qemu
+#  Run target now covered by invoking `west flash --runner=qemu` instead.
+#  run_qemu
   debugserver_qemu
   )
 
@@ -449,3 +450,22 @@ foreach(target ${qemu_targets})
     add_dependencies(${target} qemu_nvme_disk qemu_kernel_target)
   endif()
 endforeach()
+
+# Wrap the new `west flash --runner=qemu` target.
+if(WEST_DIR)
+  set(WEST "PYTHONPATH=${WEST_DIR}/src" "${PYTHON_EXECUTABLE};${WEST_DIR}/src/west/app/main.py;--zephyr-base=${ZEPHYR_BASE} ")
+endif()
+
+if(WEST)
+  add_custom_target(run_qemu COMMAND
+    COMMAND
+      ${CMAKE_COMMAND} -E env
+      ${WEST}
+      flash --runner=qemu
+    WORKING_DIRECTORY
+      ${APPLICATION_BINARY_DIR}
+    COMMENT
+      ${comment}
+    USES_TERMINAL
+  )
+endif()


### PR DESCRIPTION
This is a PoC commit showing how CMake run target can wrap west qemu runner implementation.

Before accepting this commit, the following must as minimum be done:
- Remove any old and no longer needed CMake qemu code.
- Update other emulator runners to use same principle
- Update debugserver to support same principle as run target.