### PR TITLE
net: wifi: add wifi driver version API

### DIFF
--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -51,8 +51,10 @@ extern "C" {
 
 /** Wi-Fi management commands */
 enum net_request_wifi_cmd {
+	/** Get Wi-Fi driver and Firmware version */
+	NET_REQUEST_WIFI_CMD_VERSION = 1,
 	/** Scan for Wi-Fi networks */
-	NET_REQUEST_WIFI_CMD_SCAN = 1,
+	NET_REQUEST_WIFI_CMD_SCAN,
 	/** Connect to a Wi-Fi network */
 	NET_REQUEST_WIFI_CMD_CONNECT,
 	/** Disconnect from a Wi-Fi network */
@@ -158,6 +160,11 @@ NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_PACKET_FILTER);
 
 NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_CHANNEL);
 
+#define NET_REQUEST_WIFI_VERSION			\
+	(_NET_WIFI_BASE | NET_REQUEST_WIFI_CMD_VERSION)
+
+NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_VERSION);
+
 /** Wi-Fi management events */
 enum net_event_wifi_cmd {
 	/** Scan results available */
@@ -228,6 +235,14 @@ enum net_event_wifi_cmd {
 
 #define NET_EVENT_WIFI_AP_STA_DISCONNECTED			\
 	(_NET_WIFI_EVENT | NET_EVENT_WIFI_CMD_AP_STA_DISCONNECTED)
+
+/** Wi-Fi version */
+struct wifi_version {
+	/** Driver version */
+	char *drv_version;
+	/** Firmware version */
+	char *fw_version;
+};
 
 /**
  * @brief Wi-Fi structure to uniquely identify a band-channel pair
@@ -689,6 +704,14 @@ typedef void (*raw_scan_result_cb_t)(struct net_if *iface, int status,
 
 /** Wi-Fi management API */
 struct wifi_mgmt_ops {
+	/** Get Version of WiFi driver and Firmware
+	 *
+	 * @param dev Pointer to the device structure for the driver instance
+	 * @param params Version parameters
+	 *
+	 * @return 0 if ok version, < 0 if error
+	 */
+	int (*get_version)(const struct device *dev, struct wifi_version *params);
 	/** Scan for Wi-Fi networks
 	 *
 	 * @param dev Pointer to the device structure for the driver instance.

--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -53,6 +53,8 @@ extern "C" {
 enum net_request_wifi_cmd {
 	/** Get Wi-Fi driver and Firmware version */
 	NET_REQUEST_WIFI_CMD_VERSION = 1,
+	/** Set or get MAC Address */
+	NET_REQUEST_WIFI_CMD_MAC,
 	/** Scan for Wi-Fi networks */
 	NET_REQUEST_WIFI_CMD_SCAN,
 	/** Connect to a Wi-Fi network */
@@ -164,6 +166,11 @@ NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_CHANNEL);
 	(_NET_WIFI_BASE | NET_REQUEST_WIFI_CMD_VERSION)
 
 NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_VERSION);
+
+#define NET_REQUEST_WIFI_MAC				\
+	(_NET_WIFI_BASE | NET_REQUEST_WIFI_CMD_MAC)
+
+NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_MAC);
 
 /** Wi-Fi management events */
 enum net_event_wifi_cmd {
@@ -588,6 +595,16 @@ struct wifi_reg_chan_info {
 	unsigned short dfs:1;
 } __packed;
 
+/** Wi-Fi MAC setup */
+struct wifi_mac_info {
+	/** MAC setting */
+	uint8_t mac[WIFI_MAC_ADDR_LEN];
+	/** Interface index */
+	uint8_t if_index;
+	/** Get or set operation */
+	enum wifi_mgmt_op oper;
+};
+
 /** Regulatory domain information or configuration */
 struct wifi_reg_domain {
 	/* Regulatory domain operation */
@@ -712,6 +729,14 @@ struct wifi_mgmt_ops {
 	 * @return 0 if ok version, < 0 if error
 	 */
 	int (*get_version)(const struct device *dev, struct wifi_version *params);
+	/** Set or get MAC Address
+	 *
+	 * @param dev Pointer to the device structure for the driver instance
+	 * @param MAC settings
+	 *
+	 * @return 0 if ok, < 0 if error
+	 */
+	int (*mac)(const struct device *dev, struct wifi_mac_info *params);
 	/** Scan for Wi-Fi networks
 	 *
 	 * @param dev Pointer to the device structure for the driver instance.

--- a/include/zephyr/net/wifi_utils.h
+++ b/include/zephyr/net/wifi_utils.h
@@ -55,6 +55,16 @@ extern "C" {
  */
 int wifi_utils_parse_scan_bands(char *scan_bands_str, uint8_t *band_map);
 
+/**
+ * @brief Convert ASCII string to MAC address (colon-delimited format)
+ *
+ * @param bssid_str MAC address as a string (e.g., "00:11:22:33:44:55")
+ * @param bssid Buffer for the MAC address (6 bytes)
+ *
+ * @retval 0 on success.
+ * @retval -errno value in case of failure (e.g., string not a MAC address).
+ */
+int wifi_utils_parse_bssid(char *bssid_str, uint8_t *bssid);
 
 /**
  * @brief Append a string containing an SSID to an array of SSID strings.

--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -679,6 +679,22 @@ static int wifi_channel(uint32_t mgmt_request, struct net_if *iface,
 
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_CHANNEL, wifi_channel);
 
+static int wifi_get_version(uint32_t mgmt_request, struct net_if *iface,
+			   void *data, size_t len)
+{
+	const struct device *dev = net_if_get_device(iface);
+	const struct wifi_mgmt_ops *const wifi_mgmt_api = get_wifi_api(iface);
+	struct wifi_version *ver_params = data;
+
+	if (wifi_mgmt_api == NULL || wifi_mgmt_api->get_version == NULL) {
+		return -ENOTSUP;
+	}
+
+	return wifi_mgmt_api->get_version(dev, ver_params);
+}
+
+NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_VERSION, wifi_get_version);
+
 #ifdef CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS
 void wifi_mgmt_raise_raw_scan_result_event(struct net_if *iface,
 					   struct wifi_raw_scan_result *raw_scan_result)

--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -695,6 +695,25 @@ static int wifi_get_version(uint32_t mgmt_request, struct net_if *iface,
 
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_VERSION, wifi_get_version);
 
+static int wifi_mac(uint32_t mgmt_request, struct net_if *iface, void *data, size_t len)
+{
+	const struct device *dev = net_if_get_device(iface);
+	const struct wifi_mgmt_ops *const wifi_mgmt_api = get_wifi_api(iface);
+	struct wifi_mac_info *mac_info = data;
+
+	if (dev == NULL) {
+		return -ENODEV;
+	}
+
+	if (wifi_mgmt_api == NULL || wifi_mgmt_api->mac == NULL) {
+		return -ENOTSUP;
+	}
+
+	return wifi_mgmt_api->mac(dev, mac_info);
+}
+
+NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_MAC, wifi_mac);
+
 #ifdef CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS
 void wifi_mgmt_raise_raw_scan_result_event(struct net_if *iface,
 					   struct wifi_raw_scan_result *raw_scan_result)

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -1775,6 +1775,28 @@ static int cmd_wifi_packet_filter(const struct shell *sh, size_t argc, char *arg
 	return 0;
 }
 
+static int cmd_wifi_version(const struct shell *sh, size_t argc, char *argv[])
+{
+	struct net_if *iface = net_if_get_first_wifi();
+
+	if (argc > 1) {
+		shell_fprintf(sh, SHELL_WARNING, "Invalid number of arguments\n");
+		return -ENOEXEC;
+	}
+
+	struct wifi_version version = {0};
+
+	if (net_mgmt(NET_REQUEST_WIFI_VERSION, iface, &version, sizeof(version))) {
+		shell_fprintf(sh, SHELL_WARNING, "Failed to get Wi-Fi version\n");
+		return -ENOEXEC;
+	}
+
+	shell_fprintf(sh, SHELL_NORMAL, "Wi-Fi Driver Version: %s\n", version.drv_version);
+	shell_fprintf(sh, SHELL_NORMAL, "Wi-Fi Firmware Version: %s\n", version.fw_version);
+
+	return 0;
+}
+
 SHELL_STATIC_SUBCMD_SET_CREATE(wifi_cmd_ap,
 	SHELL_CMD_ARG(disable, NULL,
 		  "Disable Access Point mode.\n",
@@ -1823,6 +1845,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(wifi_twt_ops,
 );
 
 SHELL_STATIC_SUBCMD_SET_CREATE(wifi_commands,
+	SHELL_CMD(version, NULL, "Print Wi-Fi Driver and Firmware version",
+		  cmd_wifi_version),
 	SHELL_CMD(ap, &wifi_cmd_ap, "Access Point mode commands.\n", NULL),
 	SHELL_CMD_ARG(connect, NULL,
 		  "Connect to a Wi-Fi AP\n"

--- a/subsys/net/l2/wifi/wifi_utils.c
+++ b/subsys/net/l2/wifi/wifi_utils.c
@@ -261,6 +261,27 @@ int wifi_utils_parse_scan_bands(char *scan_bands_str, uint8_t *band_map)
 	return 0;
 }
 
+int wifi_utils_parse_bssid(char *bssid_str, uint8_t *bssid)
+{
+	size_t i;
+	uint8_t a, b;
+
+	for (i = 0; i < WIFI_MAC_ADDR_LEN; i++) {
+
+		if (char2hex(*bssid_str++, &a) < 0) {
+			return -EINVAL;
+		}
+		if (char2hex(*bssid_str++, &b) < 0) {
+			return -EINVAL;
+		}
+		bssid[i] = a << 4 | b;
+		if (i < WIFI_MAC_ADDR_LEN - 1 && *bssid_str++ != ':') {
+			return -EINVAL;
+		}
+	}
+	return 0;
+}
+
 int wifi_utils_parse_scan_ssids(char *scan_ssids_str,
 				const char *ssids[],
 				uint8_t num_ssids)


### PR DESCRIPTION
Add command to query to WiFi driver/firmware revision. The API is expected to return the firmware revision and driver version as a string, and can be used by the user to determine what revision of the WiFi driver is in use.